### PR TITLE
smash-optics: use affine traversals where appropriate and fix haddock

### DIFF
--- a/smash-optics/src/Data/Can/Optics.hs
+++ b/smash-optics/src/Data/Can/Optics.hs
@@ -31,6 +31,7 @@ module Data.Can.Optics
 
 import Data.Can
 
+import Optics.AffineTraversal
 import Optics.Each.Core
 import Optics.Iso
 import Optics.IxTraversal
@@ -40,39 +41,39 @@ import Optics.Traversal
 -- ------------------------------------------------------------------- --
 -- Traversals
 
--- | A 'Optics.Traversal' of the first parameter, suitable for use
+-- | An 'AffineTraversal' of the first parameter, suitable for use
 -- with "Optics".
 --
-oneing :: Traversal (Can a c) (Can b c) a b
-oneing = traversalVL $ \f -> \case
-  Non -> pure Non
+oneing :: AffineTraversal (Can a c) (Can b c) a b
+oneing = atraversalVL $ \point f -> \case
+  Non -> point Non
   One a -> One <$> f a
-  Eno c -> pure (Eno c)
+  Eno c -> point (Eno c)
   Two a c -> flip Two c <$> f a
 
--- | A 'Optics.Traversal' of the second parameter, suitable for use
+-- | An 'AffineTraversal' of the second parameter, suitable for use
 -- with "Optics".
 --
-enoing :: Traversal (Can a b) (Can a c) b c
-enoing = traversalVL $ \f -> \case
-  Non -> pure Non
-  One a -> pure (One a)
+enoing :: AffineTraversal (Can a b) (Can a c) b c
+enoing = atraversalVL $ \point f -> \case
+  Non -> point Non
+  One a -> point (One a)
   Eno b -> Eno <$> f b
   Two a b -> Two a <$> f b
 
--- | A 'Optics.Traversal' of the pair, suitable for use
+-- | An 'AffineTraversal' of the pair, suitable for use
 -- with "Optics".
 --
 -- /Note:/ cannot change type.
 --
-twoed :: Traversal' (Can a b) (a,b)
-twoed = traversalVL $ \f -> \case
-  Non -> pure Non
-  One a -> pure (One a)
-  Eno b -> pure (Eno b)
+twoed :: AffineTraversal' (Can a b) (a,b)
+twoed = atraversalVL $ \point f -> \case
+  Non -> point Non
+  One a -> point (One a)
+  Eno b -> point (Eno b)
   Two a b -> uncurry Two <$> f (a,b)
 
--- | A 'Optics.Traversal' of the pair ala 'both', suitable for use
+-- | A 'Traversal' of the pair ala 'both', suitable for use
 -- with "Optics".
 --
 twoing :: Traversal (Can a a) (Can b b) a b
@@ -85,7 +86,7 @@ twoing = traversalVL $ \f -> \case
 -- ------------------------------------------------------------------- --
 -- Prisms
 
--- | A 'Optics.Prism'' selecting the 'Non' constructor.
+-- | A 'Prism'' selecting the 'Non' constructor.
 --
 -- /Note:/ cannot change type.
 --
@@ -96,7 +97,7 @@ _Non = prism (const Non) $ \case
   Eno b -> Left (Eno b)
   Two a b -> Left (Two a b)
 
--- | A 'Optics.Prism'' selecting the 'One' constructor.
+-- | A 'Prism'' selecting the 'One' constructor.
 --
 -- /Note:/ cannot change type.
 --
@@ -107,7 +108,7 @@ _One = prism One $ \case
   Eno b -> Left (Eno b)
   Two a b -> Left (Two a b)
 
--- | A 'Optics.Prism'' selecting the 'Eno' constructor.
+-- | A 'Prism'' selecting the 'Eno' constructor.
 --
 -- /Note:/ cannot change type.
 --
@@ -118,7 +119,7 @@ _Eno = prism Eno $ \case
   Eno b -> Right b
   Two a b -> Left (Two a b)
 
--- | A 'Optics.Prism'' selecting the 'Two' constructor.
+-- | A 'Prism'' selecting the 'Two' constructor.
 --
 -- /Note:/ cannot change type.
 --

--- a/smash-optics/src/Data/Smash/Optics.hs
+++ b/smash-optics/src/Data/Smash/Optics.hs
@@ -25,11 +25,11 @@ module Data.Smash.Optics
 ) where
 
 
+import Optics.AffineTraversal
 import Optics.Each.Core
 import Optics.Iso
 import Optics.IxTraversal
 import Optics.Prism
-import Optics.Traversal
 
 import Data.Smash
 
@@ -37,7 +37,7 @@ import Data.Smash
 -- ------------------------------------------------------------------- --
 -- Traversals
 
--- | A 'Optics.Traversal' of the smashed pair.
+-- | An 'AffineTraversal' of the smashed pair.
 --
 -- >>> over smashed (fmap pred) (Smash 1 2)
 -- Smash 1 1
@@ -45,12 +45,12 @@ import Data.Smash
 -- >>> over smashed id Nada
 -- Nada
 --
-smashed :: Traversal (Smash a b) (Smash c d) (a,b) (c,d)
-smashed = traversalVL $ \f -> \case
-  Nada -> pure Nada
+smashed :: AffineTraversal (Smash a b) (Smash c d) (a,b) (c,d)
+smashed = atraversalVL $ \point f -> \case
+  Nada -> point Nada
   Smash a b -> uncurry Smash <$> f (a,b)
 
--- | A 'Optics.Traversal' of the smashed pair.
+-- | An 'IxTraversal' of the smashed pair.
 --
 -- >>> over smashing show (Smash 1 2)
 -- Smash "1" "2"
@@ -66,7 +66,7 @@ smashing = itraversalVL $ \f -> \case
 -- ------------------------------------------------------------------- --
 -- Prisms
 
--- | A 'Optics.Prism'' selecting the 'Nada' constructor.
+-- | A 'Prism'' selecting the 'Nada' constructor.
 --
 -- /Note:/ cannot change type.
 --
@@ -75,7 +75,7 @@ _Nada = prism (const Nada) $ \case
   Nada -> Right ()
   Smash a b -> Left (Smash a b)
 
--- | A 'Optics.Prism'' selecting the 'Smash' constructor.
+-- | A 'Prism'' selecting the 'Smash' constructor.
 --
 -- /Note:/ cannot change type.
 --

--- a/smash-optics/src/Data/Wedge/Optics.hs
+++ b/smash-optics/src/Data/Wedge/Optics.hs
@@ -28,17 +28,17 @@ module Data.Wedge.Optics
 
 import Data.Wedge
 
+import Optics.AffineTraversal
 import Optics.Each.Core
 import Optics.Iso
 import Optics.IxTraversal
 import Optics.Prism
-import Optics.Traversal
 
 
 -- ------------------------------------------------------------------- --
 -- Traversals
 
--- | A 'Optics.Traversal' of the 'Here' case of a 'Wedge',
+-- | An 'AffineTraversal' of the 'Here' case of a 'Wedge',
 -- suitable for use with "Optics".
 --
 -- >>> over here show (Here 1)
@@ -47,13 +47,13 @@ import Optics.Traversal
 -- >>> over here show (There 'a')
 -- There 'a'
 --
-here :: Traversal (Wedge a b) (Wedge a' b) a a'
-here = traversalVL $ \f -> \case
-  Nowhere -> pure Nowhere
+here :: AffineTraversal (Wedge a b) (Wedge a' b) a a'
+here = atraversalVL $ \point f -> \case
+  Nowhere -> point Nowhere
   Here a -> Here <$> f a
-  There b -> pure (There b)
+  There b -> point (There b)
 
--- | A 'Optics.Traversal' of the 'There' case of a 'Wedge',
+-- | An 'AffineTraversal' of the 'There' case of a 'Wedge',
 -- suitable for use with "Optics".
 --
 -- >>> over there show (Here 1)
@@ -62,16 +62,16 @@ here = traversalVL $ \f -> \case
 -- >>> over there show (There 'a')
 -- There "'a'"
 --
-there :: Traversal (Wedge a b) (Wedge a b') b b'
-there = traversalVL $ \f -> \case
-  Nowhere -> pure Nowhere
-  Here a -> pure (Here a)
+there :: AffineTraversal (Wedge a b) (Wedge a b') b b'
+there = atraversalVL $ \point f -> \case
+  Nowhere -> point Nowhere
+  Here a -> point (Here a)
   There b -> There <$> f b
 
 -- ------------------------------------------------------------------- --
 -- Prisms
 
--- | A 'Optics.Prism'' selecting the 'Nowhere' constructor.
+-- | A 'Prism'' selecting the 'Nowhere' constructor.
 --
 -- /Note:/ this optic cannot change type.
 --
@@ -81,7 +81,7 @@ _Nowhere = prism (const Nowhere) $ \case
   Here a -> Left (Here a)
   There b -> Left (There b)
 
--- | A 'Optics.Prism'' selecting the 'Here' constructor.
+-- | A 'Prism'' selecting the 'Here' constructor.
 --
 _Here :: Prism (Wedge a b) (Wedge c b) a c
 _Here = prism Here $ \case
@@ -89,7 +89,7 @@ _Here = prism Here $ \case
   There b -> Left (There b)
   Nowhere -> Left Nowhere
 
--- | A 'Optics.Prism'' selecting the 'There' constructor.
+-- | A 'Prism'' selecting the 'There' constructor.
 --
 _There :: Prism (Wedge a b) (Wedge a d) b d
 _There = prism There $ \case


### PR DESCRIPTION
Traversals cannot be used e.g. with `preview` and `matching`.