### PR TITLE
Fix haddock formatting for smash-core

### DIFF
--- a/smash-core/src/Data/Can.hs
+++ b/smash-core/src/Data/Can.hs
@@ -110,7 +110,7 @@ some reasoning power about how this thing will be able to interact with the
 coproduct in Hask*, called 'Wedge'. Namely, facts about currying
 @Can a b -> c ~ a -> b -> c@ and distributivity over 'Wedge'
 along with other facts about its associativity, commutativity, and
-any other analogy with '(,)' that you can think of.
+any other analogy with @'(,)'@ that you can think of.
 -}
 
 
@@ -203,7 +203,7 @@ canEachA f g = canWithMerge (pure mempty) f g (liftA2 mappend)
 -- Combinators
 
 -- | Project the left value of a 'Can' datatype. This is analogous
--- to 'fst' for '(,)'.
+-- to 'fst' for @'(,)'@.
 --
 canFst :: Can a b -> Maybe a
 canFst = \case
@@ -212,7 +212,7 @@ canFst = \case
   _ -> Nothing
 
 -- | Project the right value of a 'Can' datatype. This is analogous
--- to 'snd' for '(,)'.
+-- to 'snd' for @'(,)'@.
 --
 canSnd :: Can a b -> Maybe b
 canSnd = \case
@@ -389,7 +389,7 @@ partitionCans = foldr go (empty, empty)
     go (Two a b) (as, bs) = (pure a <|> as, pure b <|> bs)
 
 -- | Partition a structure by mapping its contents into 'Can's,
--- and folding over '(<|>)'.
+-- and folding over @'(<|>)'@.
 --
 mapCans
     :: forall f t a b c
@@ -468,7 +468,7 @@ swapCan = \case
 
 -- | Curry a function from a 'Can' to a 'Maybe' value, resulting in a
 -- function of curried 'Maybe' values. This is analogous to currying
--- for '(->)'.
+-- for @'(->)'@.
 --
 canCurry :: (Can a b -> Maybe c) -> Maybe a -> Maybe b -> Maybe c
 canCurry k ma mb = case (ma, mb) of
@@ -479,7 +479,7 @@ canCurry k ma mb = case (ma, mb) of
 
 -- | "Uncurry" a function from a 'Can' to a 'Maybe' value, resulting in a
 -- function of curried 'Maybe' values. This is analogous to uncurrying
--- for '(->)'.
+-- for @'(->)'@.
 --
 canUncurry :: (Maybe a -> Maybe b -> Maybe c) -> Can a b -> Maybe c
 canUncurry k = \case

--- a/smash-core/src/Data/Can.hs
+++ b/smash-core/src/Data/Can.hs
@@ -110,7 +110,7 @@ some reasoning power about how this thing will be able to interact with the
 coproduct in Hask*, called 'Wedge'. Namely, facts about currying
 @Can a b -> c ~ a -> b -> c@ and distributivity over 'Wedge'
 along with other facts about its associativity, commutativity, and
-any other analogy with @'(,)'@ that you can think of.
+any other analogy with @(',')@ that you can think of.
 -}
 
 
@@ -203,7 +203,7 @@ canEachA f g = canWithMerge (pure mempty) f g (liftA2 mappend)
 -- Combinators
 
 -- | Project the left value of a 'Can' datatype. This is analogous
--- to 'fst' for @'(,)'@.
+-- to 'fst' for @(',')@.
 --
 canFst :: Can a b -> Maybe a
 canFst = \case
@@ -212,7 +212,7 @@ canFst = \case
   _ -> Nothing
 
 -- | Project the right value of a 'Can' datatype. This is analogous
--- to 'snd' for @'(,)'@.
+-- to 'snd' for @(',')@.
 --
 canSnd :: Can a b -> Maybe b
 canSnd = \case
@@ -389,7 +389,7 @@ partitionCans = foldr go (empty, empty)
     go (Two a b) (as, bs) = (pure a <|> as, pure b <|> bs)
 
 -- | Partition a structure by mapping its contents into 'Can's,
--- and folding over @'(<|>)'@.
+-- and folding over @('<|>')@.
 --
 mapCans
     :: forall f t a b c
@@ -468,7 +468,7 @@ swapCan = \case
 
 -- | Curry a function from a 'Can' to a 'Maybe' value, resulting in a
 -- function of curried 'Maybe' values. This is analogous to currying
--- for @'(->)'@.
+-- for @('->')@.
 --
 canCurry :: (Can a b -> Maybe c) -> Maybe a -> Maybe b -> Maybe c
 canCurry k ma mb = case (ma, mb) of
@@ -479,7 +479,7 @@ canCurry k ma mb = case (ma, mb) of
 
 -- | "Uncurry" a function from a 'Can' to a 'Maybe' value, resulting in a
 -- function of curried 'Maybe' values. This is analogous to uncurrying
--- for @'(->)'@.
+-- for @('->')@.
 --
 canUncurry :: (Maybe a -> Maybe b -> Maybe c) -> Can a b -> Maybe c
 canUncurry k = \case

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -168,14 +168,14 @@ hulkSmash a b = \case
   There d -> Smash a d
 
 -- | Project the left value of a 'Smash' datatype. This is analogous
--- to 'fst' for @'(,)'@.
+-- to 'fst' for @(',')@.
 --
 smashFst :: Smash a b -> Maybe a
 smashFst Nada = Nothing
 smashFst (Smash a _) = Just a
 
 -- | Project the right value of a 'Smash' datatype. This is analogous
--- to 'snd' for @'(,)'@.
+-- to 'snd' for @(',')@.
 --
 smashSnd :: Smash a b -> Maybe b
 smashSnd Nada = Nothing
@@ -264,7 +264,7 @@ partitionSmashes = foldr go (empty, empty)
     go (Smash a b) (as, bs) = (pure a <|> as, pure b <|> bs)
 
 -- | Partition a structure by mapping its contents into 'Smash's,
--- and folding over @'(<|>)'@.
+-- and folding over @('<|>')@.
 --
 mapSmashes
     :: forall f t a b c
@@ -280,14 +280,14 @@ mapSmashes f = partitionSmashes . fmap f
 -- Currying & Uncurrying
 
 -- | "Curry" a map from a smash product to a pointed type. This is analogous
--- to 'curry' for @'(->)'@.
+-- to 'curry' for @('->')@.
 --
 smashCurry :: (Smash a b -> Maybe c) -> Maybe a -> Maybe b -> Maybe c
 smashCurry f (Just a) (Just b) = f (Smash a b)
 smashCurry _ _ _ = Nothing
 
 -- | "Uncurry" a map of pointed types to a map of a smash product to a pointed type.
--- This is analogous to 'uncurry' for @'(->)'@.
+-- This is analogous to 'uncurry' for @('->')@.
 --
 smashUncurry :: (Maybe a -> Maybe b -> Maybe c) -> Smash a b -> Maybe c
 smashUncurry _ Nada = Nothing

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -16,7 +16,7 @@
 -- Portability  : CPP, RankNTypes, TypeApplications
 --
 -- This module contains the definition for the 'Smash' datatype. In
--- practice, this type is isomorphic to 'Maybe (a,b)' - the type with
+-- practice, this type is isomorphic to @'Maybe' (a,b)@ - the type with
 -- two possibly non-exclusive values and an empty case.
 module Data.Smash
 ( -- * Datatypes
@@ -85,7 +85,7 @@ import Data.Smash.Internal
 Categorically, the 'Smash' datatype represents a special type of product, a
 <https://ncatlab.org/nlab/show/smash+product smash product>, in the category Hask*
 of pointed Hask types. The category Hask* consists of Hask types affixed with
-a dedicated base point - i.e. all objects look like 'Maybe a'. The smash product is a symmetric, monoidal tensor in Hask* that plays
+a dedicated base point - i.e. all objects look like @'Maybe' a@. The smash product is a symmetric, monoidal tensor in Hask* that plays
 nicely with the product, 'Can', and coproduct, 'Wedge'. Pictorially,
 these datatypes look like this:
 
@@ -124,7 +124,7 @@ that makes sense to use, and that will be useful to us as Haskell developers.
 
 -- | The 'Smash' data type represents A value which has either an
 -- empty case, or two values. The result is a type, 'Smash a b', which is
--- isomorphic to 'Maybe (a,b)'.
+-- isomorphic to @'Maybe' (a,b)@.
 --
 -- Categorically, the smash product (the quotient of a pointed product by
 -- a wedge sum) has interesting properties. It forms a closed
@@ -168,14 +168,14 @@ hulkSmash a b = \case
   There d -> Smash a d
 
 -- | Project the left value of a 'Smash' datatype. This is analogous
--- to 'fst' for '(,)'.
+-- to 'fst' for @'(,)'@.
 --
 smashFst :: Smash a b -> Maybe a
 smashFst Nada = Nothing
 smashFst (Smash a _) = Just a
 
 -- | Project the right value of a 'Smash' datatype. This is analogous
--- to 'snd' for '(,)'.
+-- to 'snd' for @'(,)'@.
 --
 smashSnd :: Smash a b -> Maybe b
 smashSnd Nada = Nothing
@@ -225,7 +225,7 @@ filterNadas = foldr go []
 -- Folding
 
 -- | Fold over the 'Smash' case of a 'Foldable' of 'Smash' products by
--- some accumulatig function.
+-- some accumulating function.
 --
 foldSmashes
     :: Foldable f
@@ -264,7 +264,7 @@ partitionSmashes = foldr go (empty, empty)
     go (Smash a b) (as, bs) = (pure a <|> as, pure b <|> bs)
 
 -- | Partition a structure by mapping its contents into 'Smash's,
--- and folding over '(<|>)'.
+-- and folding over @'(<|>)'@.
 --
 mapSmashes
     :: forall f t a b c
@@ -280,14 +280,14 @@ mapSmashes f = partitionSmashes . fmap f
 -- Currying & Uncurrying
 
 -- | "Curry" a map from a smash product to a pointed type. This is analogous
--- to 'curry' for '(->)'.
+-- to 'curry' for @'(->)'@.
 --
 smashCurry :: (Smash a b -> Maybe c) -> Maybe a -> Maybe b -> Maybe c
 smashCurry f (Just a) (Just b) = f (Smash a b)
 smashCurry _ _ _ = Nothing
 
 -- | "Uncurry" a map of pointed types to a map of a smash product to a pointed type.
--- This is analogous to 'uncurry' for '(->)'.
+-- This is analogous to 'uncurry' for @'(->)'@.
 --
 smashUncurry :: (Maybe a -> Maybe b -> Maybe c) -> Smash a b -> Maybe c
 smashUncurry _ Nada = Nothing
@@ -361,7 +361,7 @@ reassocRL _ = Nada
 -- -------------------------------------------------------------------- --
 -- Symmetry
 
--- | Swap the positions of values in a 'Smash a b' to form a 'Smash b a'.
+-- | Swap the positions of values in a @'Smash' a b@ to form a @'Smash' b a@.
 --
 swapSmash :: Smash a b -> Smash b a
 swapSmash Nada = Nada

--- a/smash-core/src/Data/Wedge.hs
+++ b/smash-core/src/Data/Wedge.hs
@@ -288,7 +288,7 @@ partitionWedges = foldr go (empty, empty)
     go (There b) (as, bs) = (as, pure b <|> bs)
 
 -- | Partition a structure by mapping its contents into 'Wedge's,
--- and folding over @'(<|>)'@.
+-- and folding over @('<|>')@.
 --
 mapWedges
     :: forall f t a b c

--- a/smash-core/src/Data/Wedge.hs
+++ b/smash-core/src/Data/Wedge.hs
@@ -16,7 +16,7 @@
 -- Portability  : CPP, RankNTypes, TypeApplications
 --
 -- This module contains the definition for the 'Wedge' datatype. In
--- practice, this type is isomorphic to 'Maybe (Either a b)' - the type with
+-- practice, this type is isomorphic to @'Maybe' ('Either' a b)@ - the type with
 -- two possibly non-exclusive values and an empty case.
 module Data.Wedge
 ( -- * Datatypes
@@ -80,35 +80,35 @@ Categorically, the 'Wedge' datatype represents the coproduct (like, 'Either')
 in the category Hask* of pointed Hask types, called a <https://ncatlab.org/nlab/show/wedge+sum wedge sum>.
 The category Hask* consists of Hask types affixed with
 a dedicated base point along with an object. In Hask, this is
-equivalent to `1 + a`, also known as 'Maybe a'. Because we can conflate
+equivalent to @1 + a@, also known as @'Maybe' a@. Because we can conflate
 basepoints of different types (there is only one @Nothing@ type), the wedge sum is
-can be viewed as the type `1 + a + b`, or `Maybe (Either a b)` in Hask.
+can be viewed as the type @1 + a + b@, or @'Maybe' ('Either' a b)@ in Hask.
 Pictorially, one can visualize this as:
 
 
 @
 'Wedge':
-                a
-                |
-Nowhere +-------+
-                |
-                b
+                  a
+                  |
+'Nowhere' +-------+
+                  |
+                  b
 @
 
 
 The fact that we can think about 'Wedge' as a coproduct gives us
 some reasoning power about how a 'Wedge' will interact with the
 product in Hask*, called 'Can'. Namely, we know that a product of a type and a
-coproduct, `a * (b + c)`, is equivalent to `(a * b) + (a * c)`. Additionally,
+coproduct, @a * (b + c)@, is equivalent to @(a * b) + (a * c)@. Additionally,
 we may derive other facts about its associativity, distributivity, commutativity, and
-any more. As an exercise, think of something `Either` can do. Now do it with 'Wedge'!
+any more. As an exercise, think of something 'Either' can do. Now do it with 'Wedge'!
 
 -}
 
 -- | The 'Wedge' data type represents values with two exclusive
 -- possibilities, and an empty case. This is a coproduct of pointed
 -- types - i.e. of 'Maybe' values. The result is a type, 'Wedge a b',
--- which is isomorphic to 'Maybe (Either a b)'.
+-- which is isomorphic to @'Maybe' ('Either' a b)@.
 --
 data Wedge a b = Nowhere | Here a | There b
   deriving
@@ -138,20 +138,20 @@ wedge _ _ g (There b) = g b
 -- | Given two possible pointed types, produce a 'Wedge' by
 -- considering the left case, the right case, and mapping their
 -- 'Nothing' cases to 'Nowhere'. This is a pushout of pointed
--- types `A <- * -> B`.
+-- types @A <- * -> B@.
 --
 quotWedge :: Either (Maybe a) (Maybe b) -> Wedge a b
 quotWedge (Left a) = maybe Nowhere Here a
 quotWedge (Right b) = maybe Nowhere There b
 
--- | Convert a 'Wedge a b' into a 'Maybe (Either a b)' value.
+-- | Convert a 'Wedge a b' into a @'Maybe' ('Either' a b)@ value.
 --
 fromWedge :: Wedge a b -> Maybe (Either a b)
 fromWedge Nowhere = Nothing
 fromWedge (Here a) = Just (Left a)
 fromWedge (There b) = Just (Right b)
 
--- | Convert a 'Maybe (Either a b)' value into a 'Wedge'
+-- | Convert a @'Maybe' ('Either' a b)@ value into a 'Wedge'
 --
 toWedge :: Maybe (Either a b) -> Wedge a b
 toWedge Nothing = Nowhere
@@ -288,7 +288,7 @@ partitionWedges = foldr go (empty, empty)
     go (There b) (as, bs) = (as, pure b <|> bs)
 
 -- | Partition a structure by mapping its contents into 'Wedge's,
--- and folding over '(<|>)'.
+-- and folding over @'(<|>)'@.
 --
 mapWedges
     :: forall f t a b c


### PR DESCRIPTION
I tried to apply the suggested fixes from #3 for the smash-core. Linking seems to work for data types with using `'`, so I didn't change these cases yet.