### PR TITLE
Monad Transformers + More instances

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -36,8 +36,6 @@ jobs:
             allow-failure: false
           - ghc: 8.4.4
             allow-failure: false
-          - ghc: 8.2.2
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/smash-aeson/smash-aeson.cabal
+++ b/smash-aeson/smash-aeson.cabal
@@ -17,8 +17,7 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC ==8.2.2
-   || ==8.4.4
+  GHC ==8.4.4
    || ==8.6.5
    || ==8.8.4
    || ==8.10.4
@@ -32,7 +31,7 @@ library
 
   build-depends:
       aeson                 >=1.4   && <1.6
-    , base                  >=4.10  && <4.16
+    , base                  >=4.11  && <4.16
     , smash                 ^>=0.1.1
     , unordered-containers
 

--- a/smash-aeson/smash-aeson.cabal
+++ b/smash-aeson/smash-aeson.cabal
@@ -31,7 +31,7 @@ library
 
   build-depends:
       aeson                 >=1.4   && <1.6
-    , base                  >=4.11  && <4.16
+    , base                  >=4.1  && <4.16
     , smash                 ^>=0.1.1
     , unordered-containers
 

--- a/smash-core/CHANGELOG.md
+++ b/smash-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add Monad Transformers for `Can`, `Wedge`, and `Smash` ([#25](https://github.com/emilypi/smash/pull/25))
 * Add Safe haskell pragmas
-* Add instances for `Eq2`, `Ord2`, `Show2`, and `Read2`.
+* Add instances for all functor classes.
 * Add instances for `MonadZip`
 * Add nice pointfree definitions for some functions ([#24](https://github.com/emilypi/smash/pull/24), thanks @subttle!)
 * Add unfolds to the Api.

--- a/smash-core/CHANGELOG.md
+++ b/smash-core/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Revision history for possibly-can
+
+## 0.2
+
+* Add Monad Transformers for `Can`, `Wedge`, and `Smash` ([#25](https://github.com/emilypi/smash/pull/25))
+* Add Safe haskell pragmas
+* Add instances for `Eq2`, `Ord2`, `Show2`, and `Read2`.
+* Add instances for `MonadZip`
+* Add nice pointfree definitions for some functions ([#24](https://github.com/emilypi/smash/pull/24), thanks @subttle!)
+* Add unfolds to the Api.
+* Add template haskell `Lift` instance ([#20](https://github.com/emilypi/smash/pull/20), thanks @gergoerdi!)
+* Fixes for various haddock problems (thank you @lemastero and @L7R7!)
+* Bump base to exclude 8.2.x
+
 ## 0.1.1
 
 * Add `NFData`, `Binary` instances

--- a/smash-core/CHANGELOG.md
+++ b/smash-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for possibly-can
 
-## 0.2
+## 0.1.2
 
 * Add Monad Transformers for `Can`, `Wedge`, and `Smash` ([#25](https://github.com/emilypi/smash/pull/25))
 * Add Safe haskell pragmas

--- a/smash-core/smash.cabal
+++ b/smash-core/smash.cabal
@@ -28,17 +28,21 @@ source-repository head
 
 library
   exposed-modules:
+    Control.Monad.Trans.Can
+    Control.Monad.Trans.Smash
+    Control.Monad.Trans.Wedge
     Data.Can
     Data.Smash
     Data.Wedge
 
   other-modules:    Data.Smash.Internal
   build-depends:
-      base             >=4.10 && <4.16
+      base             >=4.11 && <4.16
     , bifunctors       ^>=5.5
     , binary           ^>=0.8
     , deepseq          ^>=1.4
     , hashable         ^>=1.3
+    , mtl
     , template-haskell >=2.2 && < 3.0
 
   hs-source-dirs:   src

--- a/smash-core/smash.cabal
+++ b/smash-core/smash.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.0
 name:               smash
-version:            0.2
+version:            0.1.2
 synopsis:           Combinators for Maybe types
 description:
   Smash products are like the 'These' datatype, only with a unit. You can

--- a/smash-core/smash.cabal
+++ b/smash-core/smash.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.0
 name:               smash
-version:            0.1.2.0
+version:            0.2
 synopsis:           Combinators for Maybe types
 description:
   Smash products are like the 'These' datatype, only with a unit. You can

--- a/smash-core/smash.cabal
+++ b/smash-core/smash.cabal
@@ -20,7 +20,7 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
+  GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 
 source-repository head
   type:     git

--- a/smash-core/src/Control/Monad/Trans/Can.hs
+++ b/smash-core/src/Control/Monad/Trans/Can.hs
@@ -4,6 +4,19 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# language Safe #-}
+-- |
+-- Module       : Control.Monad.Trans.Can
+-- Copyright    : (c) 2020-2021 Emily Pillmore
+-- License      : BSD-3-Clause
+--
+-- Maintainer   : Emily Pillmore <emilypi@cohomolo.gy>
+-- Stability    : Experimental
+-- Portability  : Non-portable
+--
+-- This module contains utilities for the monad transformer
+-- for the pointed product.
+--
 module Control.Monad.Trans.Can
 ( CanT(runCanT)
 , mapCanT
@@ -87,7 +100,7 @@ instance (Semigroup r, MonadReader r m) => MonadReader r (CanT r m) where
       Two r b -> Two (f r) b
 
 instance (Monoid s, MonadState s m) => MonadState s (CanT s m) where
-  get = CanT $ One <$> get
+  get = CanT $ Eno <$> get
   put s = CanT $ Eno <$> put s
 
 

--- a/smash-core/src/Control/Monad/Trans/Can.hs
+++ b/smash-core/src/Control/Monad/Trans/Can.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Control.Monad.Trans.Can
+( CanT(runCanT)
+, mapCanT
+) where
+
+
+import Data.Can
+import Control.Applicative (liftA2)
+import Control.Monad.Writer
+import Control.Monad.Reader
+import Control.Monad.State.Class
+import Control.Monad.Except
+
+-- | A monad transformer for the pointed product,
+-- parameterized by:
+--
+--   * @a@ - the value on the left
+--   * @b@ - the value on the right
+--   * @m@ - The monad over a pointed product (see: 'Can').
+--
+-- This monad transformer is similar to 'TheseT',
+-- except with the possibility of an empty unital value.
+--
+newtype CanT a m b = CanT { runCanT :: m (Can a b) }
+
+-- | Map both the left and right values and output of a computation using
+-- the given function.
+--
+-- * @'runCanT' ('mapCanT' f m) = f . 'runCanT' m@
+--
+mapCanT :: (m (Can a b) -> n (Can c d)) -> CanT a m b -> CanT c n d
+mapCanT f = CanT . f . runCanT
+
+instance Functor f => Functor (CanT a f) where
+  fmap f = CanT . fmap (fmap f) . runCanT
+
+instance (Semigroup a, Applicative f) => Applicative (CanT a f) where
+  pure = CanT . pure . pure
+  CanT f <*> CanT a = CanT $ liftA2 (<*>) f a
+
+instance (Semigroup a, Monad m) => Monad (CanT a m) where
+  return = pure
+
+  CanT m >>= k = CanT $ do
+    c <- m
+    case c of
+      Eno a -> runCanT $ k a
+      Two a b -> do
+        c' <- runCanT $ k b
+        return $ case c' of
+          Eno b' -> Two a b'
+          Two a' b' -> Two (a <> a') b'
+          _ -> c'
+      One a -> return $ One a
+      Non -> return Non
+
+instance (Monoid w, MonadWriter w m) => MonadWriter w (CanT w m) where
+  tell a = CanT $ Eno <$> tell a
+
+  listen (CanT m) = CanT $ go <$> listen m where
+    go (c,w) = case c of
+      Non -> Non
+      One a -> One a
+      Eno b -> Eno (b,w)
+      Two a b -> Two a (b,w)
+
+  pass (CanT m) = CanT (go <$> m) where
+    go = \case
+      Non -> Non
+      One w -> One w
+      Eno (a, _) -> Eno a
+      Two w (a, ww) -> Two (ww w) a
+
+instance (Semigroup r, MonadReader r m) => MonadReader r (CanT r m) where
+  ask = CanT (asks One)
+  local f (CanT m) = CanT (go <$> m) where
+    go = \case
+      Non -> Non
+      One r -> One (f r)
+      Eno b -> Eno b
+      Two r b -> Two (f r) b
+
+instance (Monoid s, MonadState s m) => MonadState s (CanT s m) where
+  get = CanT $ One <$> get
+  put s = CanT $ Eno <$> put s
+
+
+instance MonadTrans (CanT a) where
+  lift = CanT . fmap Eno
+
+instance (MonadError e m, Semigroup e) => MonadError e (CanT e m) where
+  throwError e = CanT $ One <$> throwError e
+  catchError (CanT m) f = CanT $ catchError m (runCanT . f)

--- a/smash-core/src/Control/Monad/Trans/Smash.hs
+++ b/smash-core/src/Control/Monad/Trans/Smash.hs
@@ -1,1 +1,96 @@
-module Control.Monad.Trans.Smash where
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# language Safe #-}
+-- |
+-- Module       : Control.Monad.Trans.Smash
+-- Copyright    : (c) 2020-2021 Emily Pillmore
+-- License      : BSD-3-Clause
+--
+-- Maintainer   : Emily Pillmore <emilypi@cohomolo.gy>
+-- Stability    : Experimental
+-- Portability  : Non-portable
+--
+-- This module contains utilities for the monad transformer
+-- for the smash product.
+--
+module Control.Monad.Trans.Smash
+( SmashT(runSmashT)
+, mapSmashT
+) where
+
+
+import Data.Smash
+import Control.Applicative (liftA2)
+import Control.Monad.Writer
+import Control.Monad.Reader
+import Control.Monad.State.Class
+
+
+-- | A monad transformer for the smash product,
+-- parameterized by:
+--
+--   * @a@ - the value on the left
+--   * @b@ - the value on the right
+--   * @m@ - The monad over a pointed product (see: 'Smash').
+--
+newtype SmashT a m b = SmashT { runSmashT :: m (Smash a b) }
+
+-- | Map both the left and right values and output of a computation using
+-- the given function.
+--
+-- * @'runSmashT' ('mapSmashT' f m) = f . 'runSmashT' m@
+--
+mapSmashT :: (m (Smash a b) -> n (Smash c d)) -> SmashT a m b -> SmashT c n d
+mapSmashT f = SmashT . f . runSmashT
+
+instance Functor f => Functor (SmashT a f) where
+  fmap f = SmashT . fmap (fmap f) . runSmashT
+
+instance (Monoid a, Applicative f) => Applicative (SmashT a f) where
+  pure = SmashT . pure . pure
+  SmashT f <*> SmashT a = SmashT $ liftA2 (<*>) f a
+
+instance (Monoid a, Monad m) => Monad (SmashT a m) where
+  return = pure
+
+  SmashT m >>= k = SmashT $ do
+    c <- m
+    case c of
+      Smash a b -> do
+        c' <- runSmashT $ k b
+        return $ case c' of
+          Nada -> Nada
+          Smash a' b' -> Smash (a <> a') b'
+      Nada -> return Nada
+
+-- instance (Monoid w, MonadWriter w m) => MonadWriter w (SmashT w m) where
+--   tell a = SmashT $ (\w -> Smash w ()) <$> tell a
+
+--   listen (SmashT m) = SmashT $ go <$> listen m where
+--     go (c,w) = case c of
+--       Nada -> Nada
+--       Smash a b -> Smash a (b,w)
+
+--   pass (SmashT m) = SmashT (go <$> m) where
+--     go = \case
+--       Nada -> Nada
+--       Smash w (a, ww) -> Smash (ww w) a
+
+-- instance (Monoid r, MonadReader r m) => MonadReader r (SmashT r m) where
+--   ask = SmashT $ asks (Smash mempty)
+--   local f (SmashT m) = SmashT (go <$> m) where
+--     go = \case
+--       Nada -> Nada
+--       Smash r b -> Smash (f r) b
+
+-- instance (Monoid s, MonadState s m) => MonadState s (SmashT s m) where
+--   get = SmashT $ Smash mempty <$> get
+--   put s = SmashT $ Smash mempty <$> put s
+
+
+-- instance MonadTrans (SmashT ()) where
+--   lift = SmashT . fmap (Smash ())

--- a/smash-core/src/Control/Monad/Trans/Smash.hs
+++ b/smash-core/src/Control/Monad/Trans/Smash.hs
@@ -1,0 +1,1 @@
+module Control.Monad.Trans.Smash where

--- a/smash-core/src/Control/Monad/Trans/Wedge.hs
+++ b/smash-core/src/Control/Monad/Trans/Wedge.hs
@@ -1,0 +1,1 @@
+module Control.Monad.Trans.Wedge where

--- a/smash-core/src/Control/Monad/Trans/Wedge.hs
+++ b/smash-core/src/Control/Monad/Trans/Wedge.hs
@@ -1,1 +1,88 @@
-module Control.Monad.Trans.Wedge where
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# language Safe #-}
+-- |
+-- Module       : Control.Monad.Trans.Wedge
+-- Copyright    : (c) 2020-2021 Emily Pillmore
+-- License      : BSD-3-Clause
+--
+-- Maintainer   : Emily Pillmore <emilypi@cohomolo.gy>
+-- Stability    : Experimental
+-- Portability  : Non-portable
+--
+-- This module contains utilities for the monad transformer
+-- for the pointed coproduct.
+--
+module Control.Monad.Trans.Wedge
+( WedgeT(runWedgeT)
+, mapWedgeT
+) where
+
+
+import Data.Wedge
+import Control.Applicative (liftA2)
+import Control.Monad.Writer
+import Control.Monad.Reader
+import Control.Monad.State.Class
+import Control.Monad.Except
+
+-- | A monad transformer for the pointed product,
+-- parameterized by:
+--
+--   * @a@ - the value on the left
+--   * @b@ - the value on the right
+--   * @m@ - The monad over a pointed coproduct (see: 'Wedge').
+--
+-- This monad transformer is similar to 'ExceptT',
+-- except with the possibility of an empty unital value.
+--
+newtype WedgeT a m b = WedgeT { runWedgeT :: m (Wedge a b) }
+
+-- | Map both the left and right values and output of a computation using
+-- the given function.
+--
+-- * @'runWedgeT' ('mapWedgeT' f m) = f . 'runWedgeT' m@
+--
+mapWedgeT :: (m (Wedge a b) -> n (Wedge c d)) -> WedgeT a m b -> WedgeT c n d
+mapWedgeT f = WedgeT . f . runWedgeT
+
+instance Functor f => Functor (WedgeT a f) where
+  fmap f = WedgeT . fmap (fmap f) . runWedgeT
+
+instance (Semigroup a, Applicative f) => Applicative (WedgeT a f) where
+  pure = WedgeT . pure . pure
+  WedgeT f <*> WedgeT a = WedgeT $ liftA2 (<*>) f a
+
+instance (Semigroup a, Monad m) => Monad (WedgeT a m) where
+  return = pure
+
+  WedgeT m >>= k = WedgeT $ do
+    c <- m
+    case c of
+      Nowhere -> return Nowhere
+      Here a -> return $ Here a
+      There a -> runWedgeT $ k a
+
+instance (Semigroup r, MonadReader r m) => MonadReader r (WedgeT r m) where
+  ask = WedgeT (asks Here)
+  local f (WedgeT m) = WedgeT (go <$> m) where
+    go = \case
+      Nowhere -> Nowhere
+      Here r -> Here (f r)
+      There b -> There b
+
+instance (Monoid s, MonadState s m) => MonadState s (WedgeT s m) where
+  get = WedgeT $ There <$> get
+  put s = WedgeT $ There <$> put s
+
+
+instance MonadTrans (WedgeT a) where
+  lift = WedgeT . fmap There
+
+instance (MonadError e m, Semigroup e) => MonadError e (WedgeT e m) where
+  throwError e = WedgeT $ Here <$> throwError e
+  catchError (WedgeT m) f = WedgeT $ catchError m (runWedgeT . f)

--- a/smash-core/src/Data/Can.hs
+++ b/smash-core/src/Data/Can.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module       : Data.Can
 -- Copyright    : (c) 2020-2021 Emily Pillmore
@@ -18,6 +19,7 @@
 -- This module contains the definition for the 'Can' datatype. In
 -- practice, this type is isomorphic to 'Maybe' 'These' - the type with
 -- two possibly non-exclusive values and an empty case.
+--
 module Data.Can
 ( -- * Datatypes
   -- $general

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -90,9 +90,6 @@ import Data.Smash.Internal
 import qualified Language.Haskell.TH.Syntax as TH
 
 
-
-
-
 {- $general
 
 Categorically, the 'Smash' datatype represents a special type of product, a

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module       : Data.Smash
 -- Copyright    : (c) 2020-2021 Emily Pillmore
@@ -18,6 +19,7 @@
 -- This module contains the definition for the 'Smash' datatype. In
 -- practice, this type is isomorphic to @'Maybe' (a,b)@ - the type with
 -- two possibly non-exclusive values and an empty case.
+--
 module Data.Smash
 ( -- * Datatypes
   -- $general

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -83,12 +82,13 @@ import Data.Hashable
 import Data.Wedge (Wedge(..))
 
 import GHC.Generics
-import GHC.Read (expectP)
+import GHC.Read
 
-import Text.Read.Lex (Lexeme(Ident))
+import Text.Read hiding (get)
 
 import Data.Smash.Internal
 import qualified Language.Haskell.TH.Syntax as TH
+
 
 
 

--- a/smash-core/src/Data/Smash/Internal.hs
+++ b/smash-core/src/Data/Smash/Internal.hs
@@ -1,3 +1,4 @@
+{-# language Safe #-}
 -- |
 -- Module       : Data.Smash.Internal
 -- Copyright    : (c) 2020-2021 Emily Pillmore
@@ -6,7 +7,7 @@
 -- Maintainer   : Emily Pillmore <emilypi@cohomolo.gy>,
 --                Asad Saeeduddin <https://github.com/masaeedu>
 -- Stability    : Experimental
--- Portability  : CPP, RankNTypes, TypeApplications
+-- Portability  : non-portable
 --
 -- This module contains utilities for distributing and codistributing
 -- bifunctors over monoidal actions.

--- a/smash-core/src/Data/Wedge.hs
+++ b/smash-core/src/Data/Wedge.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Module       : Data.Wedge
 -- Copyright    : (c) 2020-2021 Emily Pillmore
@@ -18,6 +19,7 @@
 -- This module contains the definition for the 'Wedge' datatype. In
 -- practice, this type is isomorphic to @'Maybe' ('Either' a b)@ - the type with
 -- two possibly non-exclusive values and an empty case.
+--
 module Data.Wedge
 ( -- * Datatypes
   -- $general

--- a/smash-lens/smash-lens.cabal
+++ b/smash-lens/smash-lens.cabal
@@ -19,8 +19,7 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC ==8.2.2
-   || ==8.4.4
+  GHC ==8.4.4
    || ==8.6.5
    || ==8.8.4
    || ==8.10.4
@@ -39,7 +38,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-      base   >=4.10 && <4.16
+      base   >=4.11 && <4.16
     , lens   >=4.0  && <5.0
     , smash  ^>=0.1
 

--- a/smash-microlens/smash-microlens.cabal
+++ b/smash-microlens/smash-microlens.cabal
@@ -17,8 +17,7 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC ==8.2.2
-   || ==8.4.4
+  GHC ==8.4.4
    || ==8.6.5
    || ==8.8.4
    || ==8.10.4
@@ -37,7 +36,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-      base       >=4.10 && <4.16
+      base       >=4.11 && <4.16
     , microlens  >=0.3  && <0.4.12
     , smash      ^>=0.1
 

--- a/smash-optics/smash-optics.cabal
+++ b/smash-optics/smash-optics.cabal
@@ -19,8 +19,7 @@ extra-doc-files:
   README.md
 
 tested-with:
-  GHC ==8.2.2
-   || ==8.4.4
+  GHC ==8.4.4
    || ==8.6.5
    || ==8.8.4
    || ==8.10.4
@@ -37,7 +36,7 @@ library
     Data.Wedge.Optics
 
   build-depends:
-      base         >=4.10 && <4.16
+      base         >=4.11 && <4.16
     , optics-core  ^>=0.3
     , smash        ^>=0.1
 


### PR DESCRIPTION
This PR adds the following: 

### Transformers 

- [x] A monad transformer + instances for: 
  - [x] `Can` called `CanT`
  - [x] `Wedge` called `WedgeT`
  - [x] `Smash` called `SmashT`
  
### Data.Functor.Classes

- [x] instances for `Data.Functor.Classes` (`Read2`, `Show2`, `Eq2`, `Ord2`) for 
  - [x] `Smash`
  - [x] `Wedge`
  - [x] `Can`
  
### General Instances

- [x] `MonadZip`/`Alternative`/`MonadPlus` instances 
  - [x] `Smash`
  - [x] `Can`
  - [x] `Wedge` 

### Safe Haskell

- [x] Add safe/trustworthy pragmas