### PR TITLE
Issue23

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -34,8 +34,6 @@ jobs:
             allow-failure: false
           - ghc: 8.6.5
             allow-failure: false
-          - ghc: 8.4.4
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/smash-core/smash.cabal
+++ b/smash-core/smash.cabal
@@ -40,6 +40,7 @@ library
       base             >=4.11 && <4.16
     , bifunctors       ^>=5.5
     , binary           ^>=0.8
+    , contravariant
     , deepseq          ^>=1.4
     , hashable         ^>=1.3
     , mtl

--- a/smash-core/smash.cabal
+++ b/smash-core/smash.cabal
@@ -20,7 +20,7 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
+  GHC ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 
 source-repository head
   type:     git
@@ -37,10 +37,9 @@ library
 
   other-modules:    Data.Smash.Internal
   build-depends:
-      base             >=4.11 && <4.16
+      base             >=4.12 && <4.16
     , bifunctors       ^>=5.5
     , binary           ^>=0.8
-    , contravariant
     , deepseq          ^>=1.4
     , hashable         ^>=1.3
     , mtl

--- a/smash-core/src/Data/Can.hs
+++ b/smash-core/src/Data/Can.hs
@@ -67,6 +67,7 @@ module Data.Can
 , partitionAll
 , partitionEithers
 , mapCans
+, eqCan
   -- * Distributivity
 , distributeCan
 , codistributeCan
@@ -90,6 +91,7 @@ import Data.Bitraversable
 import Data.Data
 import qualified Data.Either as E
 import Data.Functor.Classes
+import Data.Functor.Contravariant (Equivalence(..))
 import Data.Foldable
 import Data.Functor.Identity
 import Data.Hashable
@@ -490,6 +492,18 @@ mapCans
     -> t a
     -> (f b, f c)
 mapCans f = partitionCans . fmap f
+
+-- | Equivalence relation formed by grouping of equal 'Can' constructors.
+--
+eqCan :: Equivalence (Can a b)
+eqCan = Equivalence equivalence
+  where
+    equivalence :: Can a b -> Can a b -> Bool
+    equivalence Non       Non       = True
+    equivalence (One   _) (One   _) = True
+    equivalence (Eno   _) (Eno   _) = True
+    equivalence (Two _ _) (Two _ _) = True
+    equivalence _         _         = False
 
 -- -------------------------------------------------------------------- --
 -- Distributivity

--- a/smash-core/src/Data/Can.hs
+++ b/smash-core/src/Data/Can.hs
@@ -469,8 +469,8 @@ partitionEithers = go . E.partitionEithers . toList
 -- their parts.
 --
 partitionCans
-    :: Foldable t
-    => Alternative f
+    :: Alternative f
+    => Foldable t
     => t (Can a b)
     -> (f a, f b)
 partitionCans = foldr go (empty, empty)

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -55,6 +55,7 @@ module Data.Smash
   -- * Partitioning
 , partitionSmashes
 , mapSmashes
+, eqSmash
   -- * Currying & Uncurrying
 , smashCurry
 , smashUncurry
@@ -84,6 +85,7 @@ import Data.Bitraversable
 import Data.Can (Can(..), can)
 import Data.Data
 import Data.Functor.Classes
+import Data.Functor.Contravariant (Equivalence(..))
 import Data.Functor.Identity
 import Data.Hashable
 import Data.Wedge (Wedge(..))
@@ -366,6 +368,16 @@ mapSmashes
     -> t a
     -> (f b, f c)
 mapSmashes f = partitionSmashes . fmap f
+
+-- | Equivalence relation formed by grouping of equal 'Smash' constructors.
+--
+eqSmash :: Equivalence (Smash a b)
+eqSmash = Equivalence equivalence
+  where
+    equivalence :: Smash a b -> Smash a b -> Bool
+    equivalence Nada        Nada        = True
+    equivalence (Smash _ _) (Smash _ _) = True
+    equivalence _           _           = False
 
 -- -------------------------------------------------------------------- --
 -- Currying & Uncurrying

--- a/smash-core/src/Data/Smash.hs
+++ b/smash-core/src/Data/Smash.hs
@@ -348,8 +348,8 @@ accumUntilM f = go mempty
 -- their parts.
 --
 partitionSmashes
-    :: Foldable t
-    => Alternative f
+    :: Alternative f
+    => Foldable t
     => t (Smash a b) -> (f a, f b)
 partitionSmashes = foldr go (empty, empty)
   where

--- a/smash-core/src/Data/Wedge.hs
+++ b/smash-core/src/Data/Wedge.hs
@@ -365,8 +365,8 @@ accumUntilM f = go mempty
 -- their parts.
 --
 partitionWedges
-    :: Foldable t
-    => Alternative f
+    :: Alternative f
+    => Foldable t
     => t (Wedge a b) -> (f a, f b)
 partitionWedges = foldr go (empty, empty)
   where

--- a/smash-core/src/Data/Wedge.hs
+++ b/smash-core/src/Data/Wedge.hs
@@ -57,6 +57,7 @@ module Data.Wedge
   -- ** Partitioning
 , partitionWedges
 , mapWedges
+, eqWedge
   -- ** Distributivity
 , distributeWedge
 , codistributeWedge
@@ -78,6 +79,7 @@ import Data.Binary (Binary(..))
 import Data.Bitraversable
 import Data.Data
 import Data.Functor.Classes
+import Data.Functor.Contravariant (Equivalence(..))
 import Data.Functor.Identity
 import Data.Hashable
 
@@ -384,6 +386,17 @@ mapWedges
     -> t a
     -> (f b, f c)
 mapWedges f = partitionWedges . fmap f
+
+-- | Equivalence relation formed by grouping of equal 'Wedge' constructors.
+--
+eqWedge :: Equivalence (Wedge a b)
+eqWedge = Equivalence equivalence
+  where
+    equivalence :: Wedge a b -> Wedge a b -> Bool
+    equivalence Nowhere   Nowhere   = True
+    equivalence (Here  _) (Here  _) = True
+    equivalence (There _) (There _) = True
+    equivalence _         _         = False
 
 -- -------------------------------------------------------------------- --
 -- Associativity


### PR DESCRIPTION
Per https://github.com/emilypi/smash/issues/23 this PR adds `eqWedge`, `eqSmash`, and `eqCan`. GHC-8.4.4 testing is dropped to avoid adding an extra dependency on the `contravariant` package. Please let me know if you would like me to make any changes. Thank you for your time.